### PR TITLE
Inclusao da tratativa do arquivo de configuracao

### DIFF
--- a/src/model/conexao/acpdv.model.conexao.configuracao.pas
+++ b/src/model/conexao/acpdv.model.conexao.configuracao.pas
@@ -17,6 +17,9 @@ type
     procedure Comprimir;
     procedure Descomprimir;
 
+    {Criado para que possa validar e setar uma configuração provisória}
+    procedure CreateConfig;
+
     CONST
       ARQUIVOINI = 'CONFIGURACAO.CONF';
       TEMPINI = 'TEMP';
@@ -65,7 +68,26 @@ end;
 constructor TConfiguracao.Create(Path: String);
 begin
   FPath := Path;
+
+  //tratativa no caso da não existencia do arquivo de configuração
+  if not FileExists(FPath+ARQUIVOINI) then
+    CreateConfig;
+
   FArquivo := TIniFile.Create(FPath+ARQUIVOINI);
+end;
+
+procedure TConfiguracao.CreateConfig;
+begin
+  var lArquivo := TStringList.Create;
+  try
+    lArquivo.Add('[CONFIGURACAO]');
+    lArquivo.Add('DRIVEID=SQLite');
+    lArquivo.Add('DATABASE=');// Caminho para o banco de dados provisorio
+    lArquivo.SaveToFile(FPath+ARQUIVOINI);
+    Comprimir;
+  finally
+    lArquivo.DisposeOf;
+  end;
 end;
 
 procedure TConfiguracao.Descomprimir;


### PR DESCRIPTION
Neste PR tem algumas implementações provisórias para que possa compreender o ocorrido, para que possa ter maior entendimento, deve seguir o fluxo inicial, onde dentro das configurações poderá perceber o erro ocorrido, podendo assim tratar da melhor forma possível, mas o mais importante seria ter uma chamada da tela de configuração dos dados antes de acessar o PDV, como por exemplo, na própria tela de login te a chamada para configurar a base de dados.

Na implementação que criei está como provisória, desta forma pode ser mudado o tratamento, ou seguir a ideia proposta acima.